### PR TITLE
Fix SSR compatibility

### DIFF
--- a/src/InternalEvents.ts
+++ b/src/InternalEvents.ts
@@ -2,9 +2,14 @@ import { useEventListener } from "@vueuse/core";
 import { defineComponent, ref, watch, watchEffect } from "vue";
 import { useKBarHandler, useKBarState } from ".";
 
+const isClient = typeof window !== "undefined";
+
 export const InternalEvents = defineComponent({
   name: "KBarInternalEvents",
   setup() {
+    if (!isClient) {
+      return;
+    }
     useToggleHandler();
     useFocusHandler();
     useDocumentLock();


### PR DESCRIPTION
The `InternalEvents` component is used by the `KBarProvider` which can not be wrapped in a `ClientOnly` component when working with SSR or SSG projects. As the component is using `document`, the build will fail server side with the following message:

```
ReferenceError: document is not defined
```

I added a check before using client only APIs such as `document` to avoid this error.

---

The implementation is well done and setting it up was very easy!